### PR TITLE
Update server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,8 @@ app.use((req, res, next) => {
 // routes
 app.use('/api/workouts', workoutRoutes)
 
+mongoose.set('strictQuery', false);
+
 // connect to db
 mongoose.connect(process.env.MONGO_URI)
   .then(() => {


### PR DESCRIPTION
if you are getting a warning, '(node:9688) [MONGOOSE] DeprecationWarning: Mongoose: the `strictQuery` option will be switched back to `false` by default in Mongoose 7. Use `mongoose.set('strictQuery', false);` if you want to prepare for this change. Or use `mongoose.set('strictQuery', true);` to suppress this warning.      
(Use `node --trace-deprecation ...` to show where the warning was created)'